### PR TITLE
fine tune memory limits to prevent FlightSQL instance from crashing

### DIFF
--- a/charts/randoli-agent/templates/statefulset-agent.yaml
+++ b/charts/randoli-agent/templates/statefulset-agent.yaml
@@ -219,17 +219,13 @@ spec:
             value: "randoli_db_test"
           - name: INIT_SQL_COMMANDS
             value: |
-              SET memory_limit = '2GB';
-              SET threads TO 3;
+              SET memory_limit = {{ .Values.db.flightEngine.memoryLimit | quotes }};
+              SET threads TO {{ .Values.db.flightEngine.threads }};
               CREATE SCHEMA IF NOT EXISTS insights_agent;
               SET schema='insights_agent';
               SET search_path='insights_agent';
           resources:
-            limits:
-              memory: 2Gi
-            requests:
-              cpu: 50m
-              memory: 256Mi    
+            {{- toYaml .Values.db.resources | nindent 12 }}
       serviceAccountName: {{ template "randoli-agent.serviceAccountName" . }}
       serviceAccount: {{ template "randoli-agent.serviceAccountName" . }}
       {{- if or .Values.tolerations .Values.global.tolerations }}

--- a/charts/randoli-agent/templates/statefulset-agent.yaml
+++ b/charts/randoli-agent/templates/statefulset-agent.yaml
@@ -219,7 +219,7 @@ spec:
             value: "randoli_db_test"
           - name: INIT_SQL_COMMANDS
             value: |
-              SET memory_limit = {{ .Values.db.flightEngine.memoryLimit | quotes }};
+              SET memory_limit = {{ .Values.db.flightEngine.memoryLimit | squote }};
               SET threads TO {{ .Values.db.flightEngine.threads }};
               CREATE SCHEMA IF NOT EXISTS insights_agent;
               SET schema='insights_agent';

--- a/charts/randoli-agent/values.yaml
+++ b/charts/randoli-agent/values.yaml
@@ -111,6 +111,17 @@ resources:
     cpu: 50m
     memory: 512Mi
 
+db:
+  resources:
+    limits:
+      memory: 2Gi
+    requests:
+      cpu: 50m
+      memory: 256Mi
+  flightEngine:
+    memoryLimit: 1500MB
+    threads: 2
+
 anomalyDetection:
   # Defaults anomaly detection list contains detections for:
   # - memory usage spikes


### PR DESCRIPTION
- fine tune memory limits to prevent FlightSQL instance from crashing
- expose memory configs via values file in order to make them configurable