### PR TITLE
Enhancement/868hzcuvf add randoli tags to logs

### DIFF
--- a/charts/randoli-agent/templates/randoli-logs/loki-cluster-vector-pipeline.yaml
+++ b/charts/randoli-agent/templates/randoli-logs/loki-cluster-vector-pipeline.yaml
@@ -14,7 +14,7 @@ spec:
           - randoli_tags
       endpoint: {{ include "logs-loki-url" . }}
       inputs:
-        - enrich_runtime_exceptions
+        - extract_runtime_exceptions
       labels:
         forwarder: vector
         k8s_container_image: {{ `'{{ kubernetes.container_image }}'` }}
@@ -162,7 +162,7 @@ spec:
           }
       type: remap     
 
-    enrich_runtime_exceptions:
+    extract_runtime_exceptions:
       type: remap
       inputs:
         - extract_trace_from_text

--- a/charts/randoli-agent/templates/randoli-logs/loki-cluster-vector-pipeline.yaml
+++ b/charts/randoli-agent/templates/randoli-logs/loki-cluster-vector-pipeline.yaml
@@ -168,7 +168,6 @@ spec:
       source: |
         .randoli_tags = [];
         exception_data = null;
-        type = "";
 
         # convert message back to string for regex matching
         msg = string!(.message);
@@ -176,22 +175,28 @@ spec:
         if match(msg, r'^panic:\s') || match(msg, r'^fatal error:') {
 
           # golang panic
+          is_crashed = false;
+          exit = parse_regex!(msg, r'exit status (?P<code>\d+)');
+          if exit.code != 0 {
+            is_crashed = true
+          }
           if match(msg, r'^panic:\s') && (contains(msg, "goroutine") || match(msg, r'\.go:\d+')) {
             panic_msg = parse_regex!(msg, r'^panic:\s*(?P<panic_error>.+)')
             exception_data = {
-              "exception.type": panic_msg.panic_error,
-              "exception.is_crashed": true,
+              "error.kind": "panic",
+              "error.messaae": panic_msg.panic_error,
+              "error.is_crashed": is_crashed,
               "runtime": "Go"
             }
-            type = "PANIC";
+
           } else if match(msg, r'^fatal error:') {
             fatal_msg = parse_regex!(msg, r'^fatal error:\s*(?P<fatal_error>.+)')
             exception_data = {
-              "exception.type": fatal_msg.fatal_error,
-              "exception.is_crashed": true,
+              "error.kind": "fatal",
+              "error.message": fatal_msg.fatal_error,
+              "error.is_crashed": is_crashed,
               "runtime": "Go"
             }
-            type = "FATAL_ERROR";
           }
         } else if match(msg, r'^Traceback \(most recent call last\):') {
 
@@ -203,11 +208,12 @@ spec:
 
           if parsed.exception_type != null {
             exception_data = {
-              "exception.type": parsed.exception_type,
-              "runtime": "Python"
+              "runtime": "Python",
+              "error.kind": "exception",
+              "error.type": parsed.exception_type,
+              "error.has_traceback": true
             }
 
-            type = "TRACEBACK";
           }
         } else if match(msg, r'Exception in thread') || match(msg, r'(?m)^[a-zA-Z0-9_.]+(Exception|Error):') {
 
@@ -219,16 +225,16 @@ spec:
 
           if parsed.exception_type != null {
             exception_data = {
-              "exception.type": parsed.exception_type,
+              "error.kind": "exception",
+              "error.type": parsed.exception_type,
               "runtime": "Java"
             }
-            type = "EXCEPTION"
           }
         }
 
         if exception_data != null {
           .randoli_tags = push(.randoli_tags, {
-            "type": type,
+            "type": "ERROR",
             "data": exception_data
           })
         }

--- a/charts/randoli-agent/templates/randoli-logs/loki-cluster-vector-pipeline.yaml
+++ b/charts/randoli-agent/templates/randoli-logs/loki-cluster-vector-pipeline.yaml
@@ -166,76 +166,84 @@ spec:
       inputs:
         - extract_trace_from_text
       source: |
-        .randoli_tags = [];
-        exception_data = null;
 
-        # convert message back to string for regex matching
-        msg = string!(.message);
-
-        if match(msg, r'^panic:\s') || match(msg, r'^fatal error:') {
-
-          # golang panic
-          is_crashed = false;
-          exit = parse_regex!(msg, r'exit status (?P<code>\d+)');
-          if exit.code != 0 {
-            is_crashed = true
-          }
-          if match(msg, r'^panic:\s') && (contains(msg, "goroutine") || match(msg, r'\.go:\d+')) {
-            panic_msg = parse_regex!(msg, r'^panic:\s*(?P<panic_error>.+)')
-            exception_data = {
-              "error.kind": "panic",
-              "error.messaae": panic_msg.panic_error,
-              "error.is_crashed": is_crashed,
-              "runtime": "Go"
-            }
-
-          } else if match(msg, r'^fatal error:') {
-            fatal_msg = parse_regex!(msg, r'^fatal error:\s*(?P<fatal_error>.+)')
-            exception_data = {
-              "error.kind": "fatal",
-              "error.message": fatal_msg.fatal_error,
-              "error.is_crashed": is_crashed,
-              "runtime": "Go"
-            }
-          }
-        } else if match(msg, r'^Traceback \(most recent call last\):') {
-
-          # python traceback
-          parsed = parse_regex(
-            msg,
-            r'(?ms)^Traceback \(most recent call last\):.*\n(?P<exception_type>[A-Za-z_][A-Za-z0-9_.]*):'
-          ) ?? {}
-
-          if parsed.exception_type != null {
-            exception_data = {
-              "runtime": "Python",
-              "error.kind": "exception",
-              "error.type": parsed.exception_type,
-              "error.has_traceback": true
-            }
-
-          }
-        } else if match(msg, r'Exception in thread') || match(msg, r'(?m)^[a-zA-Z0-9_.]+(Exception|Error):') {
-
-          # java exception
-          parsed = parse_regex(
-            msg,
-            r'(?m)^(?:Exception in thread "[^"]+" )?(?:[a-zA-Z0-9_.]+\.)?(?P<exception_type>[A-Za-z0-9_]+(Exception|Error))'
-          ) ?? {}
-
-          if parsed.exception_type != null {
-            exception_data = {
-              "error.kind": "exception",
-              "error.type": parsed.exception_type,
-              "runtime": "Java"
-            }
-          }
+        msg = "";  
+        if is_string(.message) {
+          msg = string!(.message)
+        } else if is_object(.message) && exists(.message.message) &&
+        is_string(.message.message) {
+          msg = string!(.message.message)
         }
 
-        if exception_data != null {
-          .randoli_tags = push(.randoli_tags, {
-            "type": "ERROR",
-            "data": exception_data
-          })
+        if msg != "" {
+          .randoli_tags = [];
+          exception_data = null;
+
+          if match(msg, r'^panic:\s') || match(msg, r'^fatal error:') {
+
+            # golang panic
+            is_crashed = false;
+            exit = parse_regex!(msg, r'exit status (?P<code>\d+)');
+            if exit.code != 0 {
+              is_crashed = true
+            }
+            if match(msg, r'^panic:\s') && (contains(msg, "goroutine") || match(msg, r'\.go:\d+')) {
+              panic_msg = parse_regex!(msg, r'^panic:\s*(?P<panic_error>.+)')
+              exception_data = {
+                "error.kind": "panic",
+                "error.type": panic_msg.panic_error,
+                "error.is_crashed": is_crashed,
+                "runtime": "Go"
+              }
+
+            } else if match(msg, r'^fatal error:') {
+              fatal_msg = parse_regex!(msg, r'^fatal error:\s*(?P<fatal_error>.+)')
+              exception_data = {
+                "error.kind": "fatal",
+                "error.type": fatal_msg.fatal_error,
+                "error.is_crashed": is_crashed,
+                "runtime": "Go"
+              }
+            }
+          } else if match(msg, r'^Traceback \(most recent call last\):') {
+
+            # python traceback
+            parsed = parse_regex(
+              msg,
+              r'(?ms)^Traceback \(most recent call last\):.*\n(?P<exception_type>[A-Za-z_][A-Za-z0-9_.]*):'
+            ) ?? {}
+
+            if parsed.exception_type != null {
+              exception_data = {
+                "runtime": "Python",
+                "error.kind": "exception",
+                "error.type": parsed.exception_type,
+                "error.has_traceback": true
+              }
+
+            }
+          } else if match(msg, r'Exception in thread') || match(msg, r'(?m)^[a-zA-Z0-9_.]+(Exception|Error):') {
+
+            # java exception
+            parsed = parse_regex(
+              msg,
+              r'(?m)^(?:Exception in thread "[^"]+" )?(?:[a-zA-Z0-9_.]+\.)?(?P<exception_type>[A-Za-z0-9_]+(Exception|Error))'
+            ) ?? {}
+
+            if parsed.exception_type != null {
+              exception_data = {
+                "error.kind": "exception",
+                "error.type": parsed.exception_type,
+                "runtime": "Java"
+              }
+            }
+          }
+
+          if exception_data != null {
+            .randoli_tags = push(.randoli_tags, {
+              "type": "ERROR",
+              "data": exception_data
+            })
+          }
         }
 {{end}} 

--- a/charts/randoli-agent/templates/randoli-logs/loki-cluster-vector-pipeline.yaml
+++ b/charts/randoli-agent/templates/randoli-logs/loki-cluster-vector-pipeline.yaml
@@ -11,19 +11,17 @@ spec:
         only_fields:
           - message
           - trace_id
+          - randoli_tags
       endpoint: {{ include "logs-loki-url" . }}
       inputs:
-        - extract_trace_from_text
+        - enrich_runtime_exceptions
       labels:
         forwarder: vector
         k8s_container_image: {{ `'{{ kubernetes.container_image }}'` }}
         k8s_container_name: {{ `'{{ kubernetes.container_name }}'` }}
-        k8s_pod_ip: {{ `'{{ kubernetes.pod_ip }}'` }}
         k8s_pod_name: {{ `'{{ kubernetes.pod_name }}'` }}
         k8s_pod_namespace: {{ `'{{ kubernetes.pod_namespace }}'` }}
         k8s_pod_node_name: {{ `'{{ kubernetes.pod_node_name }}'` }}
-        k8s_pod_uid: {{ `'{{ kubernetes.pod_uid }}'` }}
-        severity: {{ `'{{ severity }}'` }}
         service_name: {{ `'{{ service_name }}'` }}
         source_type: {{ `'{{ source_type }}'` }}
       tenant_id: self-monitoring
@@ -43,121 +41,6 @@ spec:
       read_from: end
       type: kubernetes_logs
   transforms:
-    dedot_transform:
-      inputs:
-        - drop_empty_message
-      source: >-
-        . = map_keys(., recursive: true) -> |key| { replace(key, r'[./-]', "_")
-        }
-      type: remap
-    drop_empty_containers:
-      condition: '!(.kubernetes.container_name == null)'
-      inputs:
-        - merge_multiline_logs
-      type: filter
-    drop_empty_message:
-      condition: >-
-        !(strip_whitespace!(.message) == "") || !(.kubernetes.container_name ==
-        null)
-      inputs:
-        - drop_empty_containers
-      type: filter
-    drop_fields:
-      drop_on_abort: true
-      inputs:
-        - dedot_transform
-      source: |-
-        del(.kubernetes.node_labels)
-        del(.kubernetes.container_image_id)
-        del(.kubernetes.namespace_labels)
-        del(.kubernetes.pod_ip)
-        del(.kubernetes.pod_ips)
-        del(.kubernetes.pod_uid)
-      type: remap
-    extract_message:
-      inputs:
-        - drop_fields
-      source: >
-        parsed = parse_json!(.message)
-
-        .message = parsed
-
-        # Now .message contains the parsed object, and kubernetes.* fields still
-        exist
-      type: remap
-    extract_severity:
-      inputs:
-        - extract_message
-      source: >
-        # Extract severity from the message string
-
-        severity = "unknown"
-
-
-        message_str = string!(.message)
-
-
-        if contains(message_str, "CRITICAL") || contains(message_str,
-        "critical") {
-          severity = "CRITICAL"
-        } else if contains(message_str, "ERROR") || contains(message_str,
-        "error") {
-          severity = "ERROR"
-        } else if contains(message_str, "WARN") || contains(message_str,
-        "warning") || contains(message_str, "WARNING") {
-          severity = "WARNING"
-        } else if contains(message_str, "INFO") || contains(message_str, "info")
-        {
-          severity = "INFO"
-        } else if contains(message_str, "DEBUG") || contains(message_str,
-        "debug") {
-          severity = "DEBUG"
-        }
-
-
-        .severity = severity
-      type: remap
-    extract_service_name:
-      inputs:
-        - extract_severity
-      source: |
-        service_name = null
-
-        if exists(.kubernetes.pod_annotations.resource_opentelemetry_io_service_name) {
-          service_name = .kubernetes.pod_annotations.resource_opentelemetry_io_service_name
-        }
-
-        .service_name = service_name
-      type: remap 
-    extract_trace_from_json:
-      inputs:
-        - extract_service_name
-      source: |
-        trace_id = null
-
-        if exists(.message.trace_details.trace_id) {
-          trace_id = .message.trace_details.trace_id
-        }
-
-        .trace_id = trace_id
-      type: remap  
-    extract_trace_from_text:
-      inputs:
-        - extract_trace_from_json
-      source: |
-        # If we didn't find trace_id in JSON, try regex on plain text
-         if is_null(.trace_id) {
-            # Convert message back to string for regex matching
-            message_str = encode_json(.message)
-            
-            # Match pattern: traceId: <hexadecimal> (case insensitive)
-            matches = parse_regex(message_str, r'(?i)traceId:\s*(?P<trace_id>[a-f0-9]{32})') ?? null
-            
-            if !is_null(matches) {
-              .trace_id = matches.trace_id
-            }
-          }
-      type: remap
     {{- if and .Values.observability.logs.watchNamespaces (gt (len .Values.observability.logs.watchNamespaces) 0) }}
     filter_namespace:
       type: filter
@@ -170,7 +53,8 @@ spec:
           "{{ $ns }}"
           {{- end }}
         ], to_string(.kubernetes.pod_namespace) ?? "")
-    {{- end }}        
+    {{- end }} 
+  
     merge_multiline_logs:
       expire_after_ms: 2000
       group_by:
@@ -189,4 +73,163 @@ spec:
         match(string!(.message),
         r'(^\d{4}-\d{2}-\d{2}|^\d{2}:\d{2}:\d{2}|^\{"|^[A-Z]+\s)')
       type: reduce
-{{end}}       
+
+    drop_empty_containers:
+      condition: '!(.kubernetes.container_name == null)'
+      inputs:
+        - merge_multiline_logs
+      type: filter
+
+    drop_empty_message:
+      condition: >-
+        !(strip_whitespace!(.message) == "") || !(.kubernetes.container_name == null)
+      inputs:
+        - drop_empty_containers
+      type: filter
+
+    dedot_transform:
+      inputs:
+        - drop_empty_message
+      source: >-
+        . = map_keys(., recursive: true) -> |key| { replace(key, r'[./-]', "_")}
+      type: remap
+
+    drop_fields:
+      drop_on_abort: true
+      inputs:
+        - dedot_transform
+      source: |-
+        del(.kubernetes.node_labels)
+        del(.kubernetes.container_image_id)
+        del(.kubernetes.namespace_labels)
+        del(.kubernetes.pod_ip)
+        del(.kubernetes.pod_ips)
+        del(.kubernetes.pod_uid)
+      type: remap
+
+    extract_message:
+      inputs:
+        - drop_fields
+      source: >
+        parsed = parse_json!(.message);
+
+        .message = parsed; 
+        # now .message contains the parsed object, and kubernetes.* fields still exist
+
+      type: remap
+  
+    extract_service_name:
+      inputs:
+        - extract_message
+      source: |
+        service_name = null;
+
+        if exists(.kubernetes.pod_annotations.resource_opentelemetry_io_service_name) {
+          service_name = .kubernetes.pod_annotations.resource_opentelemetry_io_service_name
+        }
+
+        .service_name = service_name
+      type: remap 
+
+    extract_trace_from_json:
+      inputs:
+        - extract_service_name
+      source: |
+        trace_id = null;
+
+        if exists(.message.trace_details.trace_id) {
+          trace_id = .message.trace_details.trace_id
+        }
+
+        .trace_id = trace_id
+      type: remap  
+
+    extract_trace_from_text:
+      inputs:
+        - extract_trace_from_json
+      source: |
+         # if we didn't find trace_id in JSON, try regex on plain text
+         if is_null(.trace_id) {
+            # Convert message back to string for regex matching
+            message_str = encode_json(.message)
+            
+            # Match pattern: traceId: <hexadecimal> (case insensitive)
+            matches = parse_regex(message_str, r'(?i)traceId:\s*(?P<trace_id>[a-f0-9]{32})') ?? null
+            
+            if !is_null(matches) {
+              .trace_id = matches.trace_id
+            }
+          }
+      type: remap     
+    enrich_runtime_exceptions:
+      type: remap
+      inputs:
+        - extract_trace_from_text
+      source: |
+        .randoli_tags = [];
+        exception_data = null;
+        type = "";
+
+        # convert message back to string for regex matching
+        msg = string!(.message);
+
+        if match(msg, r'^panic:\s') || match(msg, r'^fatal error:') {
+
+          # golang panic
+          if match(msg, r'^panic:\s') && (contains(msg, "goroutine") || match(msg, r'\.go:\d+')) {
+            panic_msg = parse_regex!(msg, r'^panic:\s*(?P<panic_error>.+)')
+            exception_data = {
+              "exception.type": panic_msg.panic_error,
+              "exception.is_crashed": true,
+              "runtime": "Go"
+            }
+            type = "PANIC";
+          } else if match(msg, r'^fatal error:') {
+            fatal_msg = parse_regex!(msg, r'^fatal error:\s*(?P<fatal_error>.+)')
+            exception_data = {
+              "exception.type": fatal_msg.fatal_error,
+              "exception.is_crashed": true,
+              "runtime": "Go"
+            }
+            type = "FATAL_ERROR";
+          }
+        } else if match(msg, r'^Traceback \(most recent call last\):') {
+
+          # python traceback
+          parsed = parse_regex(
+            msg,
+            r'(?ms)^Traceback \(most recent call last\):.*\n(?P<exception_type>[A-Za-z_][A-Za-z0-9_.]*):'
+          ) ?? {}
+
+          if parsed.exception_type != null {
+            exception_data = {
+              "exception.type": parsed.exception_type,
+              "runtime": "Python"
+            }
+
+            type = "TRACEBACK";
+          }
+        } else if match(msg, r'Exception in thread') || match(msg, r'(?m)^[a-zA-Z0-9_.]+(Exception|Error):') {
+
+          # java exception
+          parsed = parse_regex(
+            msg,
+            r'(?m)^(?:Exception in thread "[^"]+" )?(?:[a-zA-Z0-9_.]+\.)?(?P<exception_type>[A-Za-z0-9_]+(Exception|Error))'
+          ) ?? {}
+
+          if parsed.exception_type != null {
+            exception_data = {
+              "exception.type": parsed.exception_type,
+              "runtime": "Java"
+            }
+            type = "EXCEPTION"
+          }
+        }
+
+        if exception_data != null {
+          .randoli_tags = push(.randoli_tags, {
+            "type": type,
+            "data": exception_data
+          })
+        }
+{{end}} 

--- a/charts/randoli-agent/templates/randoli-logs/loki-cluster-vector-pipeline.yaml
+++ b/charts/randoli-agent/templates/randoli-logs/loki-cluster-vector-pipeline.yaml
@@ -161,6 +161,7 @@ spec:
             }
           }
       type: remap     
+
     enrich_runtime_exceptions:
       type: remap
       inputs:
@@ -210,7 +211,7 @@ spec:
             # python traceback
             parsed = parse_regex(
               msg,
-              r'(?ms)^Traceback \(most recent call last\):.*\n(?P<exception_type>[A-Za-z_][A-Za-z0-9_.]*):'
+              r'Traceback .*?\n(?:.*\n)*?(?P<exception_type>[A-Za-z_][A-Za-z0-9_.]*):'
             ) ?? {}
 
             if parsed.exception_type != null {
@@ -241,7 +242,7 @@ spec:
 
           if exception_data != null {
             .randoli_tags = push(.randoli_tags, {
-              "type": "ERROR",
+              "type": "EXCEPTION",
               "data": exception_data
             })
           }


### PR DESCRIPTION
Add normalized randoli tags for runtime errors across Go, Java, and Python. All failures are categorized as ERROR, with runtime-specific details captured via error.kind and error.type.