### PR TITLE
chore: upgrade OpenCost wrapper to v1.120.3 (chart 2.5.23)

### DIFF
--- a/charts/cost-management/Chart.lock
+++ b/charts/cost-management/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: opencost
   repository: https://opencost.github.io/opencost-helm-chart
-  version: 1.42.0
-digest: sha256:1ce67eedd094ceba1692d3f11c8b496d697382d72f41bcd1325d7fb0ae78e96a
-generated: "2026-05-01T10:42:57.781582388-04:00"
+  version: 2.5.23
+digest: sha256:559ccb42af868e88afb218f995e5c9f2f70fe285a33b6aed4dda3ccd8a26bc1b
+generated: "2026-06-19T17:46:18.889114669+05:30"

--- a/charts/cost-management/Chart.yaml
+++ b/charts/cost-management/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
 name: cost-management
-description: Randoli wrapper chart for OpenCost (v1.42.0)
+description: Randoli wrapper chart for OpenCost (v2.5.23)
 type: application
-version: 1.42.0
-appVersion: "1.115.1"
+version: 2.5.23
+appVersion: "1.120.3"
 dependencies:
   - name: opencost
-    version: 1.42.0
+    version: 2.5.23
     repository: https://opencost.github.io/opencost-helm-chart

--- a/charts/cost-management/values.yaml
+++ b/charts/cost-management/values.yaml
@@ -12,7 +12,7 @@ opencost:
         registry: docker.io
         repository: randoli/opencost
         # TODO: confirm the published fork image tag for OpenCost v1.120.3 before release.
-        tag: "v1.120.3-randoli.1"
+        tag: "v1.120.3"
         pullPolicy: IfNotPresent
 
       # Prometheus query/subquery resolution -> PROMETHEUS_QUERY_RESOLUTION_SECONDS.

--- a/charts/cost-management/values.yaml
+++ b/charts/cost-management/values.yaml
@@ -35,8 +35,9 @@ opencost:
           value: "http://randoli-agent.$(POD_NAMESPACE).svc:8080"
         - name: RANDOLI_AGENT_RETRY_INTERVAL_IN_SECONDS
           value: '5'
-        - name: INSECURE_SKIP_VERIFY
-          value: "true"
+        # INSECURE_SKIP_VERIFY is emitted by the upstream opencost chart from
+        # prometheus.insecureSkipVerify below. Setting it here too produces a
+        # duplicate env key that ArgoCD's server-side-apply diff rejects.
 
       extraVolumeMounts: []
 
@@ -64,6 +65,8 @@ opencost:
             value: "30s"
 
     prometheus:
+      # Drives the upstream-rendered INSECURE_SKIP_VERIFY env var (deployment.yaml).
+      insecureSkipVerify: true
       internal:
         enabled: true
         # Matches fullnameOverride set in charts/prometheus/values.yaml

--- a/charts/cost-management/values.yaml
+++ b/charts/cost-management/values.yaml
@@ -11,8 +11,15 @@ opencost:
       image:
         registry: docker.io
         repository: randoli/opencost
-        tag: "1.115.4"
+        # TODO: confirm the published fork image tag for OpenCost v1.120.3 before release.
+        tag: "v1.120.3-randoli.1"
         pullPolicy: IfNotPresent
+
+      # Prometheus query/subquery resolution -> PROMETHEUS_QUERY_RESOLUTION_SECONDS.
+      # Default 300s (5m) is too coarse for the sparse LLM token metric, so /llm returns empty.
+      # 60s (1m) captures it; dense CPU/RAM metrics are unaffected.
+      prometheusDataSource:
+        queryResolutionSeconds: 60
 
       # CLUSTER_ID is set by the upstream chart via defaultClusterId below.
       # Override at install time: --set costManagement.opencost.opencost.exporter.defaultClusterId=<name>

--- a/charts/cost-management/values.yaml
+++ b/charts/cost-management/values.yaml
@@ -48,7 +48,7 @@ opencost:
     extraContainers:
       - name: network-cost-metrics
         image: "docker.io/randoli/network-cost-metrics:1.0.1"
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 8080
             name: http-metrics


### PR DESCRIPTION
Bump the upstream opencost dependency 1.42.0 -> 2.5.23 and align the wrapper
for the OpenCost v1.120.3 fork.

- Chart.yaml: dependency opencost 1.42.0 -> 2.5.23; appVersion -> 1.120.3;
  wrapper version -> 2.5.23.
- Chart.lock: regenerated for opencost 2.5.23.
- values.yaml:
  - image tag -> v1.120.3-randoli.1 (fork build; TODO confirm published tag
    before release).
  - set exporter.prometheusDataSource.queryResolutionSeconds: 60. The 2.5.23
    template renders this as PROMETHEUS_QUERY_RESOLUTION_SECONDS=60; the 300s
    default is too coarse for the sparse LLM token metric, leaving /llm empty.

The renamed env vars (KUBECOST_NAMESPACE -> INSTALL_NAMESPACE,
DATA_RETENTION_DAILY_RESOLUTION_DAYS -> RESOLUTION_1D_RETENTION) are handled
automatically by the 2.5.23 template; no manual env overrides needed.